### PR TITLE
docker-entrypoint.sh: init

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$SSODOMAIN" != 'example.com' ]; then
+    echo "Traitement de $SSODOMAIN"
+fi
+
+sed -i "s/example\.com/${SSODOMAIN}/g" /etc/lemonldap-ng/* \
+    /var/lib/lemonldap-ng/conf/lmConf-1.js /var/lib/lemonldap-ng/test/index.pl
+sed -i 's/CGIPassAuth on/#CGIPassAuth on/g' \
+    /etc/lemonldap-ng/portal-apache2.conf
+
+find /etc/apache2/sites-available/ -name '*.conf' ! -name '000-default.conf' \
+     -exec ln -s {} /etc/apache2/sites-enabled/ \;
+find /vhosts/ -name '*.conf' \
+     -exec ln -s {} /etc/apache2/sites-enabled/ \;
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,8 @@ if [ "$SSODOMAIN" != 'example.com' ]; then
     echo "Traitement de $SSODOMAIN"
 fi
 
+echo "ServerName $SSODOMAIN" >> /etc/apache2/apache2.conf
+
 sed -i "s/example\.com/${SSODOMAIN}/g" /etc/lemonldap-ng/* \
     /var/lib/lemonldap-ng/conf/lmConf-1.js /var/lib/lemonldap-ng/test/index.pl
 sed -i 's/CGIPassAuth on/#CGIPassAuth on/g' \


### PR DESCRIPTION
Bonjour, 

Je ne sais pas si cette PR est totalement fonctionnelle car je ne connais pas assez lemonldapng pour en être sur.

Cette PR permet de : 

- Personnaliser son domaine à chaque run du container et pas à chaque rebuild de l'image
- Utiliser un /vhosts du container pour enabled des vhosts perso dans apache2
- Pouvoir ajouter des fonctions/tests plus complets que des RUN de Dockerfile au run du container grace au script docker-entrypoint.sh

Exemple : 

> docker build . -t lemon:px

puis :

> docker run -it -p 80:80 -p 443:443 --add-host sso.labo.fr:127.0.0.1 -v $(pwd)/logs:/var/log/apache2 -e SSODOMAIN=sso.labo.fr -v $(pwd)/vhosts:/vhosts lemon:px

ou :

> docker run -it -p 80:80 -p 443:443 --add-host sso.toto.fr:127.0.0.1 -v $(pwd)/logs:/var/log/apache2 -e SSODOMAIN=sso.toto.fr -v $(pwd)/vhosts:/vhosts lemon:px

...

Merci