### PR TITLE
use low level _atp-get_ command instead of _apt_ to enable _nonintera…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,26 +6,27 @@ LABEL name="llng-apache2" \
 
 # Change SSO DOMAIN here
 ENV SSODOMAIN=example.com \
-    DUMBINITVERSION=1.2.0
+    DUMBINITVERSION=1.2.0 \
+    DEBIAN_FRONTEND=noninteractive
 
 EXPOSE 80 443
 
 COPY lemonldap-ng.list docker-entrypoint.sh /
 
 # Update system
-RUN apt -y update \
-    && apt -y install wget apt-transport-https gnupg \
-    && apt -y dist-upgrade  \
+RUN apt-get -y update \
+    && apt-get -y install wget apt-transport-https gnupg \
+    && apt-get -y dist-upgrade  \
     && echo "# Install Dumb-init" \
     && wget https://github.com/Yelp/dumb-init/releases/download/v${DUMBINITVERSION}/dumb-init_${DUMBINITVERSION}_amd64.deb \
     && dpkg -i dumb-init_${DUMBINITVERSION}_amd64.deb \
-    && apt install -f -y \
+    && apt-get install -f -y \
     && echo "# Install LemonLDAP::NG repo" \
     && mv lemonldap-ng.list /etc/apt/sources.list.d/ \
     && wget -O - https://lemonldap-ng.org/_media/rpm-gpg-key-ow2 | apt-key add - \
-    && apt -y update \
+    && apt-get -y update \
     && echo "# Install LemonLDAP::NG package" \
-    && apt -y install apache2 libapache2-mod-perl2 libapache2-mod-fcgid lemonldap-ng lemonldap-ng-fr-doc \
+    && apt-get -y install apache2 libapache2-mod-perl2 libapache2-mod-fcgid lemonldap-ng lemonldap-ng-fr-doc \
     && echo "# Change SSO Domain" \
     && sed -i "s/example\.com/${SSODOMAIN}/g" /etc/lemonldap-ng/* /var/lib/lemonldap-ng/conf/lmConf-1.js /var/lib/lemonldap-ng/test/index.pl \
     && echo "# Enable sites" \


### PR DESCRIPTION
…ctive_ frontend

When doing a `docker build` I saw multiple warnings like:
```WARNING: apt does not have a stable CLI interface. Use with caution in scripts.```

I replaced the usage of `apt` in favor of `apt-get` so the `noninteractive` debian frontend is enabled.