### PR TITLE
wip(centos): first purge any existing PID file, then start httpd

### DIFF
--- a/docker-trunk/centos/7/apache2/Dockerfile
+++ b/docker-trunk/centos/7/apache2/Dockerfile
@@ -38,4 +38,3 @@ RUN yum localinstall -y /root/rpmbuild/RPMS/noarch/*.rpm \
     && rpm -Uvh --force /root/rpmbuild/RPMS/noarch/lemonldap-ng-fr-doc*rpm
 
 ENTRYPOINT ["/usr/local/bin/dumb-init","--","/docker-entrypoint.sh"]
-CMD "/usr/sbin/apachectl" "-D" "FOREGROUND"

--- a/docker-trunk/centos/7/apache2/docker-entrypoint.sh
+++ b/docker-trunk/centos/7/apache2/docker-entrypoint.sh
@@ -1,12 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$SSODOMAIN" != 'example.com' ]; then
-    echo "Work in progress $SSODOMAIN"
+    HTTPCONF=/etc/httpd/conf.d/httpd.conf
+    if ! grep "ServerName $SSODOMAIN" "$HTTPCONF" >/dev/null; then
+	echo "Configuring LLNG for $SSODOMAIN"
+	echo "ServerName $SSODOMAIN" >>"$HTTPCONF"
+	sed -i "s/example\.com/$SSODOMAIN/g" /etc/lemonldap-ng/* \
+	    /var/lib/lemonldap-ng/conf/lmConf-1.js* /var/lib/lemonldap-ng/test/index.pl
+    else
+	echo "Re-using LLNG existing configuration for $SSODOMAIN"
+    fi
 fi
 
-echo "ServerName $SSODOMAIN" >> /etc/httpd/httpd.conf
-
-sed -i "s/example\.com/${SSODOMAIN}/g" /etc/lemonldap-ng/* \
-    /var/lib/lemonldap-ng/conf/lmConf-1.js* /var/lib/lemonldap-ng/test/index.pl
-
-exec "$@"
+rm -rf /run/httpd/* /tmp/httpd*
+exec /usr/sbin/apachectl -DFOREGROUND


### PR DESCRIPTION
also, httpd.conf is located in conf.d subfolder, previous ServerName
definition probably had no effect (?)