### PR TITLE
Switch to MPM prefork to fix mod_perl errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get -y update \
     && a2ensite portal-apache2.conf \
     && a2ensite manager-apache2.conf \
     && a2ensite test-apache2.conf \
-    && a2enmod fcgid perl alias rewrite \
+    && a2dismod mpm_event \
+    && a2enmod fcgid perl alias rewrite headers mpm_prefork \
     && echo "# Remove cached configuration" \
     && rm -rf /tmp/lemonldap-ng-config \
     && rm -fr /var/lib/apt/lists/* \


### PR DESCRIPTION
See https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng/issues/1061

It is recommended to use MPM prefork instead MPM event or MPM worker