### PR TITLE
StIck to 1.9

### DIFF
--- a/lemonldap-ng.list
+++ b/lemonldap-ng.list
@@ -1,3 +1,3 @@
 # LemonLDAP::NG repository
-deb     https://lemonldap-ng.org/deb stable main
-deb-src https://lemonldap-ng.org/deb stable main
+deb     https://lemonldap-ng.org/deb 1.9 main
+deb-src https://lemonldap-ng.org/deb 1.9 main


### PR DESCRIPTION
As of 2.0 release, Dockerfile fails to build..
The french docs package is missing, leading to broken dependencies when using `stable` branch.
Removing that package from Dockerfile, the sed command fails to edit lmConf, file has been moved.
For simplicity, posting a first PR sticking with 1.9 branch. Would look into 2.0 further later on.