### PR TITLE
Pull and install latest Nginx package frome nginx.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN echo '# Copy orignal configuration' && \
     cp -a /var/lib/lemonldap-ng/psessions /var/lib/lemonldap-ng/psessions-orig
 
 RUN echo "# Install nginx configuration files" && \
-    cd /etc/nginx/conf.d/ &&\
+    cd /etc/nginx/conf.d/ && \
     ln -s ../../lemonldap-ng/handler-nginx.conf && \
     ln -s ../../lemonldap-ng/portal-nginx.conf && \
     ln -s ../../lemonldap-ng/manager-nginx.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,23 @@ RUN echo "# Install LemonLDAP::NG source repo" && \
     wget -O - https://lemonldap-ng.org/_media/rpm-gpg-key-ow2 | apt-key add - && \
     echo "deb https://lemonldap-ng.org/deb 2.0 main" >/etc/apt/sources.list.d/lemonldap-ng.list
 
+RUN echo "# Install lib for Nginx package" && \
+    apt-get -y update && \
+    apt-get -y install curl gnupg2 ca-certificates lsb-release
+
+
+RUN echo "# Install latest Nginx" && \
+    echo "deb http://nginx.org/packages/debian `lsb_release -cs` nginx" \
+    | tee /etc/apt/sources.list.d/nginx.list &&\
+    curl -o /etc/apt/trusted.gpg.d/nginx_signing.asc https://nginx.org/keys/nginx_signing.key &&\
+    apt-get -y update && \
+    apt-get -y install nginx &&\
+    nginx -v
+
+
 RUN apt-get -y update && \
     echo "# Install LemonLDAP::NG packages" && \
-    apt-get -y install nginx lemonldap-ng cron anacron liblasso-perl libio-string-perl && \
+    apt-get -y install lemonldap-ng cron anacron liblasso-perl libio-string-perl && \
     echo "# Install LemonLDAP::NG TOTP requirements" && \
     apt-get -y install libconvert-base32-perl libdigest-hmac-perl && \
     echo "# Install some DB drivers" && \
@@ -33,17 +47,15 @@ RUN echo '# Copy orignal configuration' && \
     cp -a /var/lib/lemonldap-ng/psessions /var/lib/lemonldap-ng/psessions-orig
 
 RUN echo "# Install nginx configuration files" && \
-    cd /etc/nginx/sites-enabled/ && \
+    cd /etc/nginx/conf.d/ &&\
     ln -s ../../lemonldap-ng/handler-nginx.conf && \
     ln -s ../../lemonldap-ng/portal-nginx.conf && \
     ln -s ../../lemonldap-ng/manager-nginx.conf && \
     ln -s ../../lemonldap-ng/test-nginx.conf
-
 
 RUN echo "# Configure nginx to log to standard streams" && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 
 VOLUME ["/etc/lemonldap-ng","/var/lib/lemonldap-ng/conf", "/var/lib/lemonldap-ng/sessions", "/var/lib/lemonldap-ng/psessions"]
-
 ENTRYPOINT ["dumb-init","--","/bin/sh", "/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+NAME = coudot/lemonldap-ng
+VERSION = 2.0.11
+
+.PHONY: build build-nocache tag tag-latest
+
+build:
+	docker build -t $(NAME):$(VERSION) --rm .
+
+build-nocache:
+	docker build -t $(NAME):$(VERSION) --no-cache --rm .
+
+tag:
+	docker tag $(NAME):$(VERSION) $(NAME):$(VERSION)
+
+tag-latest:
+	docker tag $(NAME):$(VERSION) $(NAME):latest


### PR DESCRIPTION
## Purpose
Debian docker base image use outdated Nginx build (https://packages.debian.org/search?keywords=nginx).
I set the Dockerfile to pull and install Nginx from the official repository according to the documentation https://nginx.org/en/linux_packages.html#Debian. 

## Warning 
The official package use the default conf dir "conf.d" instead of "sites-availables". This should be notify in change log in order to keep track of custom volume.

We could also add a link if needed.

## Improvement 
We should fine a way to check the fingerprint of the key. 
gpg --dry-run --quiet --import --import-options import-show /tmp/nginx_signing.key throw an error that's stop the build. 


## Bonus
I also add a Makefile for more convenient build based on  [Osixia](https://github.com/osixia) template.