### PR TITLE
Use debian:stable-slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:stable
-MAINTAINER Clément OUDOT
-LABEL name="lemonldap-ng-nginx" \
-      version="v2.0"
+FROM debian:stable-slim
+LABEL   org.opencontainers.image.authors="Clément OUDOT" \
+        name="lemonldap-ng-nginx" \
+        version="v2.0"
 
 ENV SSODOMAIN=example.com \
     LOGLEVEL=info \


### PR DESCRIPTION
Using “slim” variants of the official [Debian images on the Docker Hub](https://hub.docker.com/_/debian).

`debian:stable-slim` clocks in around 74 MB, compared to 118 MB for the full image. The savings are mainly in removing documentation and locale files.