### PR TITLE
install libapache-session-ldap-perl to support LDAP backend configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get -y update && \
     apt-get -y install libauthen-webauthn-perl && \
     echo "# Install some DB drivers" && \
     apt-get -y install libdbd-mysql-perl libdbd-pg-perl && \
+    echo "# Install LDAP backend requirements" && \
+    apt-get -y install libapache-session-ldap-perl && \
     echo "\ndaemon off;" >> /etc/nginx/nginx.conf
 
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
Hey,

I know this is documented as a demo mode image, but this is the only image that's been consistently maintained in the last few years. I don't want to have to make the effort to maintain this thing myself and to be honest this demo image is almost fully equipped to be used in production.

The only thing missing is the LDAP module for perl, which could easily be installed.

Right now I'm running a custom entrypoint in my kubernetes deployment, which installs the dependency, but ideally I'd like to not have to rely on workarounds and it'd be great if you'd consider merging this change.


