### PR TITLE
Keep LLNG documentation files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ENV SSODOMAIN=example.com \
 
 EXPOSE 80
 
+# Keep documentation files for Lemonldap that are normally removed by the
+# debian-slim image
+COPY lemonldap.dpkg.cfg /etc/dpkg/dpkg.cfg.d/lemonldap
+
 RUN echo "# Install LemonLDAP::NG source repo" && \
     apt-get -y update && \
     apt-get -y install wget apt-transport-https gnupg dumb-init && \

--- a/lemonldap.dpkg.cfg
+++ b/lemonldap.dpkg.cfg
@@ -1,0 +1,1 @@
+path-include /usr/share/doc/lemonldap-ng-doc/*


### PR DESCRIPTION
Using debian-slim means that LLNG documentation is no longer present in the image and missing in the manager

![image](https://github.com/LemonLDAPNG/lemonldap-ng-docker/assets/46450505/20e13e25-b9e2-438d-aede-a4e0b1c74555)

This MR restores it